### PR TITLE
Fix Game Loop, Remove Debug.Log Spam

### DIFF
--- a/Assets/Scenes/Levels/BrutalistLevel/BrutalistLevel.unity
+++ b/Assets/Scenes/Levels/BrutalistLevel/BrutalistLevel.unity
@@ -6301,7 +6301,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!82 &1613568855
 AudioSource:
   m_ObjectHideFlags: 0
@@ -6314,7 +6314,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: bbc6fdcc01a8e114aa1530b7a225cdf4, type: 3}
   m_PlayOnAwake: 1
-  m_Volume: 0.6
+  m_Volume: 0.2
   m_Pitch: 1
   Loop: 1
   Mute: 0

--- a/Assets/Scripts/Character/AI/AIManager.cs
+++ b/Assets/Scripts/Character/AI/AIManager.cs
@@ -1,3 +1,4 @@
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -52,7 +53,8 @@ public class AIManager : MonoBehaviour
         else
         {
             Instance = this;
-            DontDestroyOnLoad(this.gameObject);
+            //TODO(Soham): This is a band-aid solution, however, I have no issue with the Instance being reinitialized on level load.
+            // DontDestroyOnLoad(this.gameObject);
         }
 
         InitializeLevel();
@@ -172,7 +174,7 @@ public class AIManager : MonoBehaviour
         // 'Respawn' the enemy at the chosen respawn point
         MoveEnemyPos(enemy, respawnPoint.transform.position);
         _numRespawns++;
-        Debug.Log("respawned an enemy");
+        // Debug.Log("respawned an enemy");
 
         // Wait to respawn more enemies
         yield return new WaitForSeconds(_respawnDelay);

--- a/Assets/Scripts/Character/AI/Enemies/Grunta.cs
+++ b/Assets/Scripts/Character/AI/Enemies/Grunta.cs
@@ -57,7 +57,7 @@ public class Grunta : SAi
         Debug.DrawRay(transform.position, moveInputVector, Color.white);
         Debug.DrawRay(transform.position, Vector3.Project(moveInputVector, right), Color.red);
         Debug.DrawRay(transform.position, Vector3.Project(moveInputVector, forward), Color.blue);
-        Debug.Log($"Velx is {_anim.GetFloat(VelX)}");
-        Debug.Log($"Vely is {_anim.GetFloat(VelY)}");
+        //Debug.Log($"Velx is {_anim.GetFloat(VelX)}");
+        //Debug.Log($"Vely is {_anim.GetFloat(VelY)}");
     }
 }

--- a/Assets/Scripts/Character/AI/SAi.cs
+++ b/Assets/Scripts/Character/AI/SAi.cs
@@ -237,7 +237,6 @@ public class SAi : SCharacter
         
         for (var i = 0; i < numLinkDrops; i++)
         {
-            Debug.Log($"Dropping link {i} of {numLinkDrops}");
             var randomX = Random.Range(-1f, 1f);
             var randomY = Random.Range(.3f, .8f);
             var randomZ = Random.Range(-1f, 1f);

--- a/Assets/Scripts/Character/Player/APlayer.cs
+++ b/Assets/Scripts/Character/Player/APlayer.cs
@@ -264,7 +264,7 @@ public abstract class APlayer : SCharacter
     public override void Damage(float damage) {
         OnDamage?.Invoke();
         base.Damage(damage);
-        Debug.Log(damage);
+        // Debug.Log(damage);
     }
 
     public override void Kill()

--- a/Assets/Scripts/LinkMagnet.cs
+++ b/Assets/Scripts/LinkMagnet.cs
@@ -34,9 +34,7 @@ public class LinkMagnet : MonoBehaviour
 
     private void OnTriggerEnter(Collider collision)
     {
-        Debug.Log("coll on magnet");
         if (collision.gameObject.GetComponent<APlayer>() != GameManager.Instance.aPlayer) return;
-        Debug.Log("collide with player!");
         _target = collision.gameObject.transform;
     }
 
@@ -44,7 +42,7 @@ public class LinkMagnet : MonoBehaviour
     {
         if (!_linkDrop) Destroy(this);
         if (!_target) return;
-        Debug.Log("adding magnet force");
+        // Debug.Log("adding magnet force");
         var dirToPlayer = (_target.position - _linkDrop.gameObject.transform.position).normalized;
         _linkDropRigidbody.AddForce(dirToPlayer * attractForce, ForceMode.Force);
     }

--- a/Assets/Scripts/Weapon/RangedWeapon.cs
+++ b/Assets/Scripts/Weapon/RangedWeapon.cs
@@ -389,12 +389,12 @@ public abstract class RangedWeapon : MonoBehaviour
         var r = new Ray(hit.point, Vector3.down);
         if (Physics.Raycast(r, out var groundHit, 10f, 1 << LayerMask.NameToLayer("Default")))
         {
-            Debug.Log($"Hit found with height {groundHit.point.y} on object {groundHit.collider.gameObject.name}");
+            // Debug.Log($"Hit found with height {groundHit.point.y} on object {groundHit.collider.gameObject.name}");
             settings.GroundHeight = groundHit.point.y;
         }
         else
         {
-            Debug.LogWarning("No hit found with ground.");
+            // Debug.LogWarning("No hit found with ground.");
         }
         settings.AnimationSpeed = 2;
         settings.FreezeDecalDisappearance = true;


### PR DESCRIPTION
This PR contains two major changes:

1. The line in AIManager that marks its GameObject as DontDestroyOnLoad has been commented out. Going forward, if Soham chooses, this change can be reverted, as long as the game loop functions properly.

2. Most (nearly all) Debug.Log messages have been removed. Many of them were used for old debugging of old scripts, and were cluttering the cocnsole and negatively impacting performance. In general (and this goes for me, too) Debug.Log messages should be relatively rare, and certainly not be printed every frame.