### PR TITLE
add object pooling

### DIFF
--- a/Assets/Prefabs/Characters/Players/Kuze.prefab
+++ b/Assets/Prefabs/Characters/Players/Kuze.prefab
@@ -52,7 +52,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   motor: {fileID: 5751729091738824338}
-  health: 100
+  health: 1000
   maxStableMoveSpeed: 10
   stableMovementSharpness: 15
   orientationSharpness: 15
@@ -65,7 +65,7 @@ MonoBehaviour:
   jumpScalableForwardSpeed: 10
   jumpPreGroundingGraceTime: 0
   jumpPostGroundingGraceTime: 0
-  _weapon: {fileID: 0}
+  _weapon: {fileID: 7429496413570663606}
   aimingMovementPenalty: 0.75
   ignoredColliders: []
   layerMask:
@@ -410,6 +410,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e43bcf993c30d2342a813623ec1a138a, type: 3}
+--- !u!114 &7429496413570663606 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6437781830929478806, guid: e43bcf993c30d2342a813623ec1a138a,
+    type: 3}
+  m_PrefabInstance: {fileID: 4489323467881639968}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fc7191658b8eddc418eb9ad0c877c80a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &8671529013921423829
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Managers/GameManager.prefab
+++ b/Assets/Prefabs/Managers/GameManager.prefab
@@ -11,6 +11,12 @@ GameObject:
   - component: {fileID: 2606140551033211468}
   - component: {fileID: 2606140551033211469}
   - component: {fileID: 4426868419963979292}
+  - component: {fileID: 1356622599}
+  - component: {fileID: 1356622600}
+  - component: {fileID: 1356622603}
+  - component: {fileID: 1356622604}
+  - component: {fileID: 1356622605}
+  - component: {fileID: 1356622606}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -59,6 +65,129 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3d06051d5d30f014eb9ad5bf88847f3b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  levelsData: []
-  _minRespawnDistance: 100
-  _respawnDelay: 2
+  test: {fileID: 0}
+  levelsData:
+  - {fileID: 11400000, guid: f454970e4997b1f4da6cad75195e6a5c, type: 2}
+  _minRespawnDistance: 10
+  _respawnDelay: 0.1
+--- !u!114 &1356622599
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2606140551033211466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d878469f925348146b71452d9fe6dc07, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  objects:
+  - {fileID: 2656253210798625995, guid: a78e9ef18b366424b84e0c7410d2fe72, type: 3}
+  - {fileID: 5865290276592450837, guid: 42a28376f729c864a81abf66add7a418, type: 3}
+  - {fileID: 764304066602274965, guid: 4a322f29a9e1fa54f90223de8bcf3a28, type: 3}
+  - {fileID: 7935733108997359171, guid: e822d59151d3597428b0b63bf25355e7, type: 3}
+  - {fileID: 4288107571095694937, guid: c3f8938673a07704e93ac52eee18f410, type: 3}
+  - {fileID: 1165703760847671896, guid: bb596cd440832554089a7125852e836f, type: 3}
+  - {fileID: 4152240900433254336, guid: 6d3629f845b40e24fb51d381e84bbc77, type: 3}
+  - {fileID: 6463355840203370170, guid: 70ead61ff20b23b4e97b90d8e8997ecd, type: 3}
+  - {fileID: 5170585893340993107, guid: 7b88f11816abaa34c9e02cbaa8485321, type: 3}
+  - {fileID: 2629016494315086251, guid: 5776aed3bb070e54cb09a11c8a6a5831, type: 3}
+  - {fileID: 3034872428933141512, guid: 52d94bfe44b09ff4b9e9788e9a86a778, type: 3}
+  - {fileID: 2360933683143488451, guid: 730678b8a5330c449ada55bde83402ce, type: 3}
+  - {fileID: 5016170632959171363, guid: c3ed06559a66b724b91c3124e75ddec9, type: 3}
+  - {fileID: 8859926575668995837, guid: 097a30048e9007141899f834041a5ac7, type: 3}
+  - {fileID: 5936082179827903908, guid: cb58ece77d11ef945aecd072f2e46a8d, type: 3}
+  - {fileID: 5494213943435191861, guid: db51fe09adf27d640b4e10018c2d76ba, type: 3}
+  - {fileID: 5371219466416337994, guid: f9e099178c81bee439a79eecec91dacb, type: 3}
+  collectionChecks: 1
+  initPoolSize: 10
+  maxPoolSize: 500
+  maxBloodOnScreen: 150
+--- !u!114 &1356622600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2606140551033211466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45b5f7947df5fb9439a549a9979b24aa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  objects:
+  - {fileID: 141106, guid: 0c2fb496ab06a364fb16faf0f4528004, type: 3}
+  collectionChecks: 1
+  initPoolSize: 10
+  maxPoolSize: 500
+--- !u!114 &1356622603
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2606140551033211466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7ea3e53520db304f85539b360fe9db2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  objects:
+  - {fileID: 6774897497785466354, guid: 8cfe437906c21dd41ae4d2c242640624, type: 3}
+  collectionChecks: 1
+  initPoolSize: 10
+  maxPoolSize: 500
+--- !u!114 &1356622604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2606140551033211466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 461fcae642b5e3b4da5b2eb637034271, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  objects:
+  - {fileID: 178032, guid: ea6cf4c5efb69b94db988e2fbfd72698, type: 3}
+  collectionChecks: 1
+  initPoolSize: 10
+  maxPoolSize: 500
+  surfaceType: 0
+--- !u!114 &1356622605
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2606140551033211466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 461fcae642b5e3b4da5b2eb637034271, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  objects:
+  - {fileID: 108086, guid: 547c2e12da8d4214098216299e70a3ba, type: 3}
+  collectionChecks: 1
+  initPoolSize: 10
+  maxPoolSize: 500
+  surfaceType: 3
+--- !u!114 &1356622606
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2606140551033211466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e3ffc41cffc5e246bae4f525faae298, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  objects:
+  - {fileID: 1210114176842607944, guid: 73b4cddbbab90744c8d202c5bd01a1c7, type: 3}
+  collectionChecks: 1
+  initPoolSize: 10
+  maxPoolSize: 500

--- a/Assets/Prefabs/VFX/KuzeMachinePistolFlash.prefab
+++ b/Assets/Prefabs/VFX/KuzeMachinePistolFlash.prefab
@@ -4735,7 +4735,6 @@ ParticleSystemRenderer:
   m_RendererPriority: 0
   m_Materials:
   - {fileID: 2100000, guid: cd54c3146f0d82147af127d64e856ea8, type: 2}
-  - {fileID: 0}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -9573,7 +9572,6 @@ ParticleSystemRenderer:
   m_RendererPriority: 0
   m_Materials:
   - {fileID: 2100000, guid: 25e227ee40b33da4dbbe73008d65c8df, type: 2}
-  - {fileID: 0}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Prefabs/VFX/MuzzleFlashes/Prefab/Impacts/PlasterImpact.prefab
+++ b/Assets/Prefabs/VFX/MuzzleFlashes/Prefab/Impacts/PlasterImpact.prefab
@@ -9635,7 +9635,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 178040}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1f6f8e03260dedb45a05a2c5f5eea632, type: 3}
   m_Name: 

--- a/Assets/Prefabs/VFX/MuzzleFlashes/Scripts/FPSShaderColorGradient.cs
+++ b/Assets/Prefabs/VFX/MuzzleFlashes/Scripts/FPSShaderColorGradient.cs
@@ -3,6 +3,7 @@ using System.Collections;
 
 public class FPSShaderColorGradient : MonoBehaviour
 {
+    public ImpactEffectSurface.ImpactSurfaceType surfaceType;
     public RFX4_ShaderProperties ShaderColorProperty = RFX4_ShaderProperties._TintColor;
     public Gradient Color = new Gradient();
     public float TimeMultiplier = 1;
@@ -48,6 +49,12 @@ public class FPSShaderColorGradient : MonoBehaviour
     private void Update()
     {
         rend.GetPropertyBlock(props);
+
+        if (props.GetColor(propertyID).a == 0)
+        {
+            GameManager.Instance.SurfaceImpactPools[surfaceType].Release(transform.parent.gameObject);
+            return;
+        }
 
         var time = Time.time - startTime;
         if (canUpdate)

--- a/Assets/Prefabs/VFX/VolumetricBloodFX/Prefabs/Blood2.prefab
+++ b/Assets/Prefabs/VFX/VolumetricBloodFX/Prefabs/Blood2.prefab
@@ -30,6 +30,7 @@ Transform:
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
   m_LocalPosition: {x: 4.51, y: -2, z: -0.14}
   m_LocalScale: {x: 9.716193, y: 1, z: 2.3172183}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5865290276592450839}
   m_RootOrder: 0
@@ -53,10 +54,12 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -81,6 +84,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &5865290275427856750
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -248,6 +252,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: -0.131, y: 0, z: 0}
   m_LocalScale: {x: 0.02, y: 0.02, z: 0.02}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5865290276592450839}
   m_RootOrder: 1
@@ -271,10 +276,12 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -299,6 +306,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &5865290275503222905
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,6 +374,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5865290275427856748}
   - {fileID: 5865290275503222918}

--- a/Assets/Prefabs/VFX/VolumetricBloodFX/Prefabs/Blood4.prefab
+++ b/Assets/Prefabs/VFX/VolumetricBloodFX/Prefabs/Blood4.prefab
@@ -27,6 +27,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6262922503611694314}
   - {fileID: 2110413278929217436}
@@ -80,6 +81,7 @@ Transform:
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.012, y: 0.012, z: 0.012}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2118898371229433452}
   m_RootOrder: 1
@@ -103,10 +105,12 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -131,6 +135,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &1374528034777412430
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -201,6 +206,7 @@ Transform:
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
   m_LocalPosition: {x: 1.1232, y: -0.954, z: -0.047999382}
   m_LocalScale: {x: 1.9126978, y: 1, z: 2.8669147}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2118898371229433452}
   m_RootOrder: 0
@@ -224,10 +230,12 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -252,6 +260,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &6262922503611694313
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/VFX/VolumetricBloodFX/Scripts/BFX_DecalSettings.cs
+++ b/Assets/Prefabs/VFX/VolumetricBloodFX/Scripts/BFX_DecalSettings.cs
@@ -43,6 +43,7 @@ public class BFX_DecalSettings : MonoBehaviour
     private void ShaderCurve_OnAnimationFinished()
     {
         GetComponent<Renderer>().enabled = false;
+        GameManager.Instance.BloodPool.Release(tParent.gameObject);
     }
 
     private void Update()

--- a/Assets/Scenes/Levels (DO NOT DIRECTLY EDIT, DUPLICATE A LEVEL TO MODIFY IT)/Museum.unity
+++ b/Assets/Scenes/Levels (DO NOT DIRECTLY EDIT, DUPLICATE A LEVEL TO MODIFY IT)/Museum.unity
@@ -37650,7 +37650,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-7398
+  m_Name: pb_Mesh48002
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -41828,16 +41828,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 2514021088258454746, guid: fa166f60e418001478edbb9d49465641,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2668975553678954865, guid: fa166f60e418001478edbb9d49465641,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 5751729091738824349, guid: fa166f60e418001478edbb9d49465641,
         type: 3}
       propertyPath: m_RootOrder
@@ -41897,16 +41887,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Kuze
-      objectReference: {fileID: 0}
-    - target: {fileID: 5751729091738824351, guid: fa166f60e418001478edbb9d49465641,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9146898649614295160, guid: fa166f60e418001478edbb9d49465641,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fa166f60e418001478edbb9d49465641, type: 3}
@@ -42178,32 +42158,6 @@ PrefabInstance:
       propertyPath: aPlayer
       value: 
       objectReference: {fileID: 250520939}
-    - target: {fileID: 4426868419963979292, guid: fdf674b9093d43946bde9035ab3bac7a,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4426868419963979292, guid: fdf674b9093d43946bde9035ab3bac7a,
-        type: 3}
-      propertyPath: _respawnDelay
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4426868419963979292, guid: fdf674b9093d43946bde9035ab3bac7a,
-        type: 3}
-      propertyPath: _minRespawnDistance
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 4426868419963979292, guid: fdf674b9093d43946bde9035ab3bac7a,
-        type: 3}
-      propertyPath: levelsData.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4426868419963979292, guid: fdf674b9093d43946bde9035ab3bac7a,
-        type: 3}
-      propertyPath: levelsData.Array.data[0]
-      value: 
-      objectReference: {fileID: 11400000, guid: f454970e4997b1f4da6cad75195e6a5c,
-        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fdf674b9093d43946bde9035ab3bac7a, type: 3}
 --- !u!1001 &1955149865

--- a/Assets/Scripts/BloodPool.cs
+++ b/Assets/Scripts/BloodPool.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BloodPool : GameObjectPool
+{
+    [SerializeField] private int maxBloodOnScreen = 50;
+    
+    private readonly Queue<BFX_BloodSettings> _bloodFadeQueue = new();
+    
+    protected override GameObject CreatePooledItem()
+    {
+        var blood = base.CreatePooledItem();
+        var settings = blood.GetComponent<BFX_BloodSettings>();
+        settings.DecalRenderinMode = BFX_BloodSettings._DecalRenderinMode.AverageRayBetwenForwardAndFloor;
+        settings.AnimationSpeed = 2;
+        if (GameManager.Instance.dirLight) settings.LightIntensityMultiplier = GameManager.Instance.dirLight.intensity;
+        return blood;
+    }
+
+    protected override void OnTakeFromPool(GameObject obj)
+    {
+        base.OnTakeFromPool(obj);
+        var settings = obj.GetComponent<BFX_BloodSettings>();
+        settings.FreezeDecalDisappearance = true;
+        _bloodFadeQueue.Enqueue(settings);
+        if (_bloodFadeQueue.Count > maxBloodOnScreen)
+        {
+            _bloodFadeQueue.Dequeue().FreezeDecalDisappearance = false;
+        }
+    }
+}

--- a/Assets/Scripts/BloodPool.cs.meta
+++ b/Assets/Scripts/BloodPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d878469f925348146b71452d9fe6dc07
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BulletTrailPool.cs
+++ b/Assets/Scripts/BulletTrailPool.cs
@@ -1,0 +1,12 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BulletTrailPool : GameObjectPool
+{
+    protected override void OnTakeFromPool(GameObject obj)
+    {
+        base.OnTakeFromPool(obj);
+        obj.GetComponent<TrailFade>().color.a = 100;
+    }
+}

--- a/Assets/Scripts/BulletTrailPool.cs.meta
+++ b/Assets/Scripts/BulletTrailPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7ea3e53520db304f85539b360fe9db2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Character/AI/Backend/SAi.cs
+++ b/Assets/Scripts/Character/AI/Backend/SAi.cs
@@ -11,8 +11,6 @@ public class SAi : SCharacter
     [Range(0, 100)]
     public float linkValue = 20;
 
-    public GameObject linkObj;
-    
     protected BehaviourTreeRunner TreeRunner;
     protected BehaviourTree BehaviourTree;
     protected SAiInputs Inputs;
@@ -242,15 +240,17 @@ public class SAi : SCharacter
             var randomY = Random.Range(.3f, .8f);
             var randomZ = Random.Range(-1f, 1f);
             var throwVector = new Vector3(randomX, randomY, randomZ).normalized;
-            var linkDrop = Instantiate(linkObj, transform.position, Quaternion.identity);
+            // var linkDrop = Instantiate(linkObj, transform.position, Quaternion.identity);
+            var linkDrop = GameManager.Instance.LinkPool.Get();
+            linkDrop.transform.position = transform.position;
             linkDrop.GetComponentInChildren<LinkDrop>().value = linkValue / 5f;
             linkDrop.GetComponentInChildren<Rigidbody>().AddForce(throwVector, ForceMode.Impulse);
             yield return new WaitForSeconds(.5f);
         }
-        this.enabled = false;
-
+        //Is this a problem area?
+        enabled = false;
         yield return new WaitForSeconds(15f);
-        this.gameObject.SetActive(false);
+        gameObject.SetActive(false);
     }
 
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -3,7 +3,9 @@ using System.Threading;
 using System.Collections;
 using System.Collections.Generic;
 using KinematicCharacterController.Examples;
+using Unity.VisualScripting;
 using UnityEngine;
+using UnityEngine.Pool;
 using UnityEngine.SceneManagement;
 
 public class GameManager : MonoBehaviour
@@ -24,6 +26,22 @@ public class GameManager : MonoBehaviour
     public static Action<APlayer> PlayerDeath;
     public static Action<GameObject> EnemyDeath;
 
+    private BloodPool _bloodPoolComponent;
+    public ObjectPool<GameObject> BloodPool;
+
+    private MuzzleFlashPool _muzzleFlashPoolComponent;
+    public ObjectPool<GameObject> MuzzleFlashPool;
+
+    private BulletTrailPool _bulletTrailPoolComponent;
+    public ObjectPool<GameObject> BulletTrailPool;
+
+    private SurfaceImpactPool[] _surfaceImpactPoolComponents;
+    public readonly Dictionary<ImpactEffectSurface.ImpactSurfaceType, ObjectPool<GameObject>> SurfaceImpactPools = new();
+
+    private LinkPool _linkPoolComponent;
+    public ObjectPool<GameObject> LinkPool;
+
+
     private void Awake()
     {
         //Initialize the instance of the Game Manager.
@@ -41,6 +59,24 @@ public class GameManager : MonoBehaviour
         
         PlayerDeath += OnPlayerDeath;
         EnemyDeath += OnEnemyDeath;
+
+        _bloodPoolComponent = GetComponent<BloodPool>();
+        BloodPool = _bloodPoolComponent.Pool;
+
+        _muzzleFlashPoolComponent = GetComponent<MuzzleFlashPool>();
+        MuzzleFlashPool = _muzzleFlashPoolComponent.Pool;
+
+        _bulletTrailPoolComponent = GetComponent<BulletTrailPool>();
+        BulletTrailPool = _bulletTrailPoolComponent.Pool;
+
+        _surfaceImpactPoolComponents = GetComponents<SurfaceImpactPool>();
+        foreach (var component in _surfaceImpactPoolComponents)
+        {
+            SurfaceImpactPools.Add(component.surfaceType, component.Pool);
+        }
+
+        _linkPoolComponent = GetComponent<LinkPool>();
+        LinkPool = _linkPoolComponent.Pool;
     }
 
     void TryFindAPlayer()
@@ -50,7 +86,7 @@ public class GameManager : MonoBehaviour
 
     Light TryFindDirLight()
     {
-        foreach (var light in GameObject.FindObjectsOfType<Light>())
+        foreach (var light in FindObjectsOfType<Light>())
         {
             if (light.type == LightType.Directional) return light;
         }

--- a/Assets/Scripts/GameObjectPool.cs
+++ b/Assets/Scripts/GameObjectPool.cs
@@ -1,0 +1,52 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Pool;
+
+public abstract class GameObjectPool : MonoBehaviour
+{
+    [SerializeField] private GameObject[] objects;
+    [SerializeField] private bool collectionChecks = true;
+    [SerializeField] private int initPoolSize = 10;
+    [SerializeField] private int maxPoolSize = 500;
+    
+    ObjectPool<GameObject> m_Pool;
+
+    public ObjectPool<GameObject> Pool
+    {
+        get
+        {
+            if (m_Pool == null)
+            {
+                m_Pool = new ObjectPool<GameObject>(CreatePooledItem, OnTakeFromPool, OnReturnedToPool, OnDestroyPoolObject, collectionChecks, initPoolSize, maxPoolSize);
+            }
+
+            return m_Pool;
+        }
+    }
+
+    protected virtual GameObject CreatePooledItem()
+    {
+        if (objects.Length == 0) return null;
+        return Instantiate(objects.Length > 1 ? objects[Random.Range(0, objects.Length)] : objects[0]);
+    }
+
+    protected virtual void OnTakeFromPool(GameObject obj)
+    {
+        obj.SetActive(true);
+    }
+
+    protected virtual void OnReturnedToPool(GameObject obj)
+    {
+        obj.SetActive(false);
+    }
+
+    protected void OnDestroyPoolObject(GameObject obj)
+    {
+        Debug.LogWarning($"Object pool {name} deleted an instance of object {obj.name}. Increase size of pool.");
+        Destroy(obj);
+    }
+    
+    
+
+}

--- a/Assets/Scripts/GameObjectPool.cs.meta
+++ b/Assets/Scripts/GameObjectPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cad40048c8f2357468b5105ff0494eb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Link/LinkDrop.cs
+++ b/Assets/Scripts/Link/LinkDrop.cs
@@ -27,7 +27,7 @@ public class LinkDrop : MonoBehaviour
               3)) return;
         GameManager.Instance.aPlayer.Heal(value);
         // StartCoroutine(ReduceBleed(2f, 1));
-        Destroy(gameObject);
+        GameManager.Instance.LinkPool.Release(gameObject);
     }
 
     // IEnumerator ReduceBleed(float seconds, int amount)

--- a/Assets/Scripts/Link/LinkMagnet.cs
+++ b/Assets/Scripts/Link/LinkMagnet.cs
@@ -46,4 +46,9 @@ public class LinkMagnet : MonoBehaviour
         var dirToPlayer = (_target.position - _linkDrop.gameObject.transform.position).normalized;
         _linkDropRigidbody.AddForce(dirToPlayer * attractForce, ForceMode.Force);
     }
+
+    public void ResetTarget()
+    {
+        _target = null;
+    }
 }

--- a/Assets/Scripts/LinkPool.cs
+++ b/Assets/Scripts/LinkPool.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class LinkPool : GameObjectPool
+{
+    protected override void OnReturnedToPool(GameObject obj)
+    {
+        obj.GetComponent<Rigidbody>().velocity = Vector3.zero;
+        obj.GetComponentInChildren<LinkMagnet>().ResetTarget();
+        base.OnReturnedToPool(obj);
+    }
+}

--- a/Assets/Scripts/LinkPool.cs.meta
+++ b/Assets/Scripts/LinkPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e3ffc41cffc5e246bae4f525faae298
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MuzzleFlashPool.cs
+++ b/Assets/Scripts/MuzzleFlashPool.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MuzzleFlashPool : GameObjectPool
+{
+    
+}

--- a/Assets/Scripts/MuzzleFlashPool.cs.meta
+++ b/Assets/Scripts/MuzzleFlashPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45b5f7947df5fb9439a549a9979b24aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SurfaceImpactPool.cs
+++ b/Assets/Scripts/SurfaceImpactPool.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SurfaceImpactPool : GameObjectPool
+{
+    public ImpactEffectSurface.ImpactSurfaceType surfaceType;
+
+    protected override GameObject CreatePooledItem()
+    {
+        var obj = base.CreatePooledItem();
+        var gradient = obj.GetComponentInChildren<FPSShaderColorGradient>();
+        gradient.surfaceType = surfaceType;
+        return obj;
+    }
+    
+}

--- a/Assets/Scripts/SurfaceImpactPool.cs.meta
+++ b/Assets/Scripts/SurfaceImpactPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 461fcae642b5e3b4da5b2eb637034271
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/VFX/TrailFade.cs
+++ b/Assets/Scripts/VFX/TrailFade.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class TrailFade : MonoBehaviour
 {
     [SerializeField] private float trailFadeSpeed = 10f;
-    [SerializeField] private Color color;
+    [SerializeField] public Color color;
 
     private LineRenderer _lr;
     // Start is called before the first frame update
@@ -21,5 +21,6 @@ public class TrailFade : MonoBehaviour
         color.a = Mathf.Lerp(color.a, 0, trailFadeSpeed * Time.deltaTime);
         _lr.startColor = color;
         _lr.endColor = color;
+        if (color.a <= .1f) GameManager.Instance.BulletTrailPool.Release(gameObject);
     }
 }

--- a/Assets/Scripts/Weapon/Weapons/HitscanTestWeapon.cs
+++ b/Assets/Scripts/Weapon/Weapons/HitscanTestWeapon.cs
@@ -30,19 +30,29 @@ public class HitscanTestWeapon : RangedWeapon
         PlayFireEffect();
         DrawHitscanBulletTrail(hitPoint);
     }
+    
+    public void PlayFireEffect()
+    {
+        var fireEffectInstance = GameManager.Instance.MuzzleFlashPool.Get();
+        fireEffectInstance.transform.position = barrelTransform.position;
+        fireEffectInstance.transform.rotation = barrelTransform.rotation;
+        fireEffectInstance.transform.parent = barrelTransform;
+        if (AudioSource) AudioSource.PlayOneShot(AudioSource.clip);
+        StartCoroutine(ReleaseMuzzleFlashWaiter(4f, fireEffectInstance));
+    }
+    
+    IEnumerator ReleaseMuzzleFlashWaiter(float numSeconds, GameObject toRelease)
+    {
+        yield return new WaitForSeconds(numSeconds);
+        GameManager.Instance.MuzzleFlashPool.Release(toRelease);
+    }
 
     private void DrawHitscanBulletTrail(Vector3 hitPos)
     {
-        if (!hitscanBulletTrail) return;
-        
-        var trailObj = Instantiate(hitscanBulletTrail, barrelTransform.position, Quaternion.identity);
+        var trailObj = GameManager.Instance.BulletTrailPool.Get();
         var lineRenderer = trailObj.GetComponent<LineRenderer>();
-        
-        if (!lineRenderer) return;
-        
         lineRenderer.SetPosition(0, barrelTransform.position);
         lineRenderer.SetPosition(1, hitPos);
-        Destroy(trailObj, 1f);
     }
 
 }

--- a/Assets/Scripts/Weapon/Weapons/StandardBulletWeapon.cs
+++ b/Assets/Scripts/Weapon/Weapons/StandardBulletWeapon.cs
@@ -33,4 +33,20 @@ public class StandardBulletWeapon : RangedWeapon
         rb.AddForce(dir.normalized * weaponData.firingForce, ForceMode.Impulse);
         PlayFireEffect();
     }
+    
+    public void PlayFireEffect()
+    {
+        var fireEffectInstance = GameManager.Instance.MuzzleFlashPool.Get();
+        fireEffectInstance.transform.position = barrelTransform.position;
+        fireEffectInstance.transform.rotation = barrelTransform.rotation;
+        fireEffectInstance.transform.parent = barrelTransform;
+        if (AudioSource) AudioSource.PlayOneShot(AudioSource.clip);
+        StartCoroutine(ReleaseMuzzleFlashWaiter(4f, fireEffectInstance));
+    }
+    
+    IEnumerator ReleaseMuzzleFlashWaiter(float numSeconds, GameObject toRelease)
+    {
+        yield return new WaitForSeconds(numSeconds);
+        GameManager.Instance.MuzzleFlashPool.Release(toRelease);
+    }
 }


### PR DESCRIPTION
EVERYTHING:

- muzzles flashes
- bullet trails
- blood effects
- bullet impacts
- link drops

IS NOW OBJECT POOLED

GameManager has attached components which extend GameObjectPool. These are specific pools for certain gameobject types that many classes may find useful to summon at runtime. They all draw from the same central bucket, so a lot of memory is reused.

This should make performance MUCH better on ALL machines