### PR TITLE
literally leaderboards

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -13,6 +13,8 @@ public class GameManager : MonoBehaviour
 
     public static GameManager Instance { get; private set; }
 
+    public static Leaderboards leaderboards { get; private set; }
+
     [Header("Player Character")] public APlayer aPlayer;
     public RangedWeapon playerWeapon { get; private set; }
     public Light dirLight;
@@ -54,6 +56,8 @@ public class GameManager : MonoBehaviour
             Instance = this;
         }
         
+        Leaderboards leaderboards = gameObject.AddComponent<Leaderboards>();
+
         if (!aPlayer) TryFindAPlayer();
         if (!dirLight) dirLight = TryFindDirLight();
         

--- a/Assets/Scripts/Utility/Leaderboards.cs
+++ b/Assets/Scripts/Utility/Leaderboards.cs
@@ -1,0 +1,99 @@
+using UnityEngine;
+using UnityEngine.Networking;
+using System.Collections;
+using System.Collections.Generic;
+
+public class Leaderboards : MonoBehaviour
+{
+
+    public readonly string uri = "https://web-production-7cdc.up.railway.app/api/";
+
+    public List<PlayerScore> leaderboards = new List<PlayerScore>();
+
+    private bool jobQueued = false;
+    private PlayerScore job;
+
+    void Start()
+    {
+        StartCoroutine(FetchLeaderboards());
+    }
+
+    void Update()
+    {
+        if (jobQueued)
+        {
+            StartCoroutine(PushNewScore(job));
+            jobQueued = false;
+        }
+    }
+
+    public void QueueNewScore(PlayerScore job)
+    {
+        this.job = job;
+        jobQueued = true;
+    }
+
+    public List<PlayerScore> Top10()
+    {
+        leaderboards.Sort((p1, p2) => p2.score - p1.score);
+        
+        int size = leaderboards.Count > 10 ? 10 : leaderboards.Count;
+
+        List<PlayerScore> output = new List<PlayerScore>();
+        for (int i = 0; i < size; i++){
+            output.Add(leaderboards[i]);
+        }
+
+        return output;
+    }
+
+    IEnumerator PushNewScore(PlayerScore job)
+    {
+        string data = "updatescore?username=" + job.username + "&score=" + job.score;
+        List<IMultipartFormSection> formData = new List<IMultipartFormSection>();
+
+        UnityWebRequest www = UnityWebRequest.Post(uri + data, formData);
+        yield return www.SendWebRequest();
+
+        if (www.result != UnityWebRequest.Result.Success)
+        {
+            Debug.LogError("LEADERBOARD cannot update score " + www.error);
+        }
+        else
+        {
+            Debug.Log("LEADERBOARD: Form upload complete!");
+        }
+    }
+
+    IEnumerator FetchLeaderboards()
+    {
+        using (UnityWebRequest webRequest = UnityWebRequest.Get(uri + "leaderboard"))
+        {
+            // Request and wait for the desired page.
+            yield return webRequest.SendWebRequest();
+
+            if (webRequest.result == UnityWebRequest.Result.Success)
+            {
+                foreach (string part in webRequest.downloadHandler.text.Split("},"))
+                {
+                    int index = part.IndexOf("username");
+                    string leftover = part.Substring(index + 11);
+                    string username = leftover.Substring(0, leftover.IndexOf(",") - 1);
+                    index = part.IndexOf("score");
+                    leftover = part.Substring(index + 8);
+                    string score = leftover.Substring(0, leftover.IndexOf(",") - 1);
+                    PlayerScore player = new PlayerScore(username, int.Parse(score));
+                    leaderboards.Add(player);
+                }
+                Debug.Log("LEADERBOARD: fetch complete");
+            }
+            else
+            {
+                Debug.LogError("LEADERBOARD Unable to retrieve leaderboards: " + webRequest.error);
+            }
+
+        }
+    }
+
+
+}

--- a/Assets/Scripts/Utility/Leaderboards.cs.meta
+++ b/Assets/Scripts/Utility/Leaderboards.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0bfeac07a186643ffb672d75e7da5d5a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/PlayerScore.cs
+++ b/Assets/Scripts/Utility/PlayerScore.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+public struct PlayerScore
+{
+    public string username;
+    public int score;
+
+    public PlayerScore(string username, int score) {
+        this.username = username;
+        this.score = score;
+    }
+}

--- a/Assets/Scripts/Utility/PlayerScore.cs.meta
+++ b/Assets/Scripts/Utility/PlayerScore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ed3886874658445787d67ea519124dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Okay so this was finished hours ago but LFS broke my macbook and it took about 1 hour to fetch all the files and switch branches... anyways here is the leaderboard.

GameManager already creates an instance of Leaderboard which will fetch all player scores from the server + database (this was done earlier and exists in michelle692/starfall-leaderboard github). 

How to use:
To get the top 10 players scores, just do 
```GameManager.leaderboards.Top10()``` which will give you a List<PlayerScore>.

To insert a new player score into global database, just do:
```GameManager.leaderboards.QueueNewJob(new PlayerScore("bahti", 10000))```. 

Probably should add a way to refetch all the leaderboards after updating score but you can just include one more line of code in Update to StartCourtine(FetchLeaderboards()).

If you have questions, leave a comment? 